### PR TITLE
grammar correction in variable (foundIndex) name

### DIFF
--- a/src/Control/Climbing.cpp
+++ b/src/Control/Climbing.cpp
@@ -333,11 +333,11 @@ int TestClimb(B_Entity *entity, unsigned int eventIndex)
 
 void SetClimbingData(B_ClimbingData *climbingData)
 {
-    int foundedIndex = climbing_data_list.FindItemIndex(climbingData->Id());
+    int foundIndex = climbing_data_list.FindItemIndex(climbingData->Id());
     // If previous climbing was interrupted then we should remove existing data
-    if (foundedIndex != -1)
+    if (foundIndex != -1)
     {
-        climbing_data_list.Remove(foundedIndex, true);
+        climbing_data_list.Remove(foundIndex, true);
     }
     climbing_data_list.Append(climbingData);
 }


### PR DESCRIPTION
As explained [here](https://github.com/smartblade/BldPatch/issues/1#issuecomment-1029512984) it is merely grammar correction to variable name.
